### PR TITLE
Property set accessors can be protected as well

### DIFF
--- a/ZenSharp.Integration/Templates.ltg
+++ b/ZenSharp.Integration/Templates.ltg
@@ -28,8 +28,8 @@ access ::= (internal=i | public=p | private=_ | protected=P) space
 
 // Auto properties:
 property        ::= access ("abstract "=pa | "static "=P | "virtual "=pv | ""=p) type space identifier propertyBody cursor
-propertyBody    ::= "{ get;" lazyPrivateSpec " set; }"
-lazyPrivateSpec ::= "private "="+p" | "protected "="+P" | ""
+propertyBody    ::= "{ get;" propertySetAccessor " set; }"
+propertySetAccessor ::= "protected "="+p" | ""="+" | "private "
 
 // Methods:
 method ::= access ("abstract "=am | "static "=M | ""=m) (type | "void") space identifier methodArgs methodBody


### PR DESCRIPTION
This can be discussed that how to activate the property set accessors. I've use the following 
+p for private 
+P for protected
and by default no accessor.
